### PR TITLE
use parse_server_url from BuildProperties

### DIFF
--- a/backbone-parse.js
+++ b/backbone-parse.js
@@ -82,7 +82,7 @@ var api_version = window.BuildProperties.parse_api_version;
 	    options || (options = {});
 
         var base_url = /api.parse.com/.test(parse_server_url)
-            ? parse_server_url + "/" + api_version + "/classes"
+            ? parse_server_url + api_version + "/classes"
             : parse_server_url + "/classes";
 
         var url = base_url + "/" + class_name + "/";

--- a/backbone-parse.js
+++ b/backbone-parse.js
@@ -1,5 +1,6 @@
 /********** PARSE API ACCESS CREDENTIALS **********/
 
+var parse_server_url = window.BuildProperties.parse_server_url;
 var application_id = window.BuildProperties.parse_application_id;
 var rest_api_key = window.BuildProperties.parse_rest_key;
 var api_version = window.BuildProperties.parse_api_version;
@@ -79,8 +80,13 @@ var api_version = window.BuildProperties.parse_api_version;
         // create request parameteres
 		var type = methodMap[method];
 	    options || (options = {});
-		var base_url = "https://api.parse.com/" + api_version + "/classes";
-		var url = base_url + "/" + class_name + "/";
+
+        var base_url = /api.parse.com/.test(parse_server_url)
+            ? parse_server_url + "/" + api_version + "/classes"
+            : parse_server_url + "/classes";
+
+        var url = base_url + "/" + class_name + "/";
+
         if (method != "create") {
             url = url + object_id;
         }


### PR DESCRIPTION
As Parse is being shutdown, this will support apps that use parse-server. `parse_server_url` without trailing `/` must be passed in through `build.config`
  
e.g:
* `https://api.parse.com`
* `https://api.self-hosted-parse.com/parse`